### PR TITLE
update for eslint 1.0 config

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -19,10 +19,15 @@
     "no-mixed-spaces-and-tabs": 2,
     "no-trailing-spaces": 2,
     "no-use-before-define": [2, "nofunc"],
-    "no-unused-vars": 1,
+    "no-unused-vars": [1, {
+      "vars": "all",
+      "args": "none"
+    }],
     "quotes": [2, "double", "avoid-escape"],
     "semi": [2, "always"],
     "space-after-keywords": [2, "always"],
-    "space-in-brackets": [2, "never"]
+    "object-curly-spacing": [2, "never"],
+    "computed-property-spacing": [2, "never"],
+    "array-bracket-spacing": [2, "never"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "The eyeglass team and contributors",
     "url": "https://github.com/sass-eyeglass/eyeglass-dev-eslint/graphs/contributors"
   },
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "main": "index.js",
   "README": "README.md",
   "scripts": {
@@ -17,6 +17,6 @@
     "url": "https://github.com/sass-eyeglass/eyeglass-dev-eslint.git"
   },
   "dependencies": {
-    "eslint": "^1.0.0"
+    "eslint": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/sass-eyeglass/eyeglass-dev-eslint.git"
+  },
+  "dependencies": {
+    "eslint": "^1.0.0"
   }
 }


### PR DESCRIPTION
This includes two fixes:

First, it updates the json config to be compliant with ESLint 1.0. The [`space-in-brackets` option is deprecated](https://github.com/eslint/eslint/blob/master/docs/rules/space-in-brackets.md) in favor of the separate options:  `object-curly-spacing`, `computed-property-spacing` and `array-bracket-spacing`. This also adds a dependency on `eslint@^1.0.0`.

Second, it cross-merges changes that were committed to the [`eyeglass-dev-eslint` 1.0.1 tag](https://github.com/sass-eyeglass/eyeglass-dev-eslint/commit/fa579301592d274289a3be8aaf25364e6eeadd0e), but didn't make it to master.
