### PR TITLE
Replace removed space-after-keywords option with keyword-spacing option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": ["./eslint.json"]
+}

--- a/eslint.json
+++ b/eslint.json
@@ -25,7 +25,7 @@
     }],
     "quotes": [2, "double", "avoid-escape"],
     "semi": [2, "always"],
-    "space-after-keywords": [2, "always"],
+    "keyword-spacing": [2, {"before": true, "after": true}],
     "object-curly-spacing": [2, "never"],
     "computed-property-spacing": [2, "never"],
     "array-bracket-spacing": [2, "never"]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "index.js",
   "README": "README.md",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint test/fixtures/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "url": "https://github.com/sass-eyeglass/eyeglass-dev-eslint.git"
   },
   "dependencies": {
-    "eslint": "^1.1.0"
+    "eslint": "^3.8.1"
   }
 }

--- a/test/fixtures/test_pass.js
+++ b/test/fixtures/test_pass.js
@@ -1,0 +1,10 @@
+"use strict";
+
+// Test
+
+function test () {
+  var test = "test";
+  console.log(test);
+}
+
+test();


### PR DESCRIPTION
This PR replaces the in recent eslint releases removed space-after-keywords option with its replacement option, keyword-spacing. The keyword-spacing settings should be functionally equivalent to the previous outdated eslint configuration.
